### PR TITLE
let's try this

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,6 @@ dependencies:
   - ioos_qc
   - ipyleaflet
   - jupyter
-  - jupyter-rsession-proxy
   - jupyter_contrib_nbextensions
   - jupyterlab
   - matplotlib-base


### PR DESCRIPTION
@abkfenris I could not find RStudio readily available on ubuntu repos, so let's just remove this.