### PR TITLE
Fix docker caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-#syntax=docker/dockerfile:1.2
+#syntax=docker/dockerfile:1.3
 # Most of the stuff here is from:
 # https://github.com/2i2c-org/pilot-hubs/tree/master/images/user
 # and
@@ -72,7 +72,7 @@ RUN /tmp/install-miniforge.bash
 USER ${NB_USER}
 
 COPY --chown=jovyan:jovyan conda-linux-64.lock /tmp/conda-linux-64.lock
-RUN --mount=type=cache,target=${CONDA_DIR}/pkgs \
+RUN --mount=type=cache,target=${CONDA_DIR}/pkgs,uid=1000,gid=1000 \
     conda install --name ${CONDA_ENV} --file /tmp/conda-linux-64.lock && \
     find -name '*.a' -delete && \
     # rm -rf /opt/conda/conda-meta && \

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - conda-lock
   - ctd
   - dask
-  - dask-gateway
+  - dask-gateway=0.9.0  # needs to match underlying dask-gateway-server on cluster which is most likely to match https://github.com/2i2c-org/pilot-hubs/blob/master/images/user/requirements.txt
   - distributed
   - datashader
   - descartes


### PR DESCRIPTION
The previous issue with [permissions](https://github.com/oceanhackweek/jupyter-image/runs/3210916114?check_suite_focus=true#step:5:476) (once I changed conda to install as jovyan) looks to be because of a difference in which `Dockerfile` syntax was running locally vs with Actions. 

Locally it would build correctly, but on Actions it would fail trying to install the conda environment due to the cache permissions being off.

Initially I thought this was because Actions was using an older Dockerfile syntax, while my computer was defaulting to `# syntax=docker/dockerfile:1.2`. Once I forced them to be the same by adding the syntax line at the top of the `Dockerfile` they acted the same way.

It appears however that setting the syntax to 1.2 broke the caching of conda packages. The cache was defined as `RUN --mount=type=cache,target=${CONDA_DIR}/pkgs ...`. 

Syntax 1.2 apparently didn't support variable expansion, so `${CONDA_DIR}` didn't get turned into `/srv/conda`. Therefore the cache was getting set up at exactly `${CONDA_DIR}/pkgs`, which didn't have any interaction locally. 

Syntax 1.3 started to support variable expansion in `RUN --mount`, so `${CONDA_DIR}/pkgs` appropriately became `/srv/conda/pkgs`.

Unfortunately, the cache also needs to handle permissions, so `uid=1000,guid=100` needed to get added to the cache definition.

Drops image size back down from 7.35 GB to 5.1.

It looks like the 1.3 syntax went [official](https://www.docker.com/blog/engineering-update-buildkit-0-9-and-docker-buildx-0-6-releases/) on 2021-07-28.