### PR TITLE
Let's give this repo2docker trick a try

### DIFF
--- a/r/Dockerfile
+++ b/r/Dockerfile
@@ -97,6 +97,8 @@ ENV PATH /usr/lib/rstudio-server/bin/:${PATH}
 
 ENV LD_LIBRARY_PATH=${CONDA_DIR}/lib
 ENV PROJ_LIB=${CONDA_DIR}/share/proj
+ENV GDAL_DATA=${CONDA_DIR}/share/gdal
+ENV GDAL_DRIVER_PATH=${CONDA_DIR}/lib/gdalplugins
 
 # USER root
 # RUN chown -R jovyan ${CONDA_DIR}

--- a/r/Dockerfile
+++ b/r/Dockerfile
@@ -5,7 +5,7 @@ ENV NB_USER jovyan
 ENV NB_UID 1000
 ENV HOME /home/jovyan
 
-ENV CONDA_DIR /srv/conda
+ENV CONDA_DIR /opt/conda
 ENV CONDA_ENV base
 ENV R_LIBS_USER /opt/r
 
@@ -94,6 +94,8 @@ RUN Rscript -e "remotes::install_cran('assertthat', dependencies=FALSE, upgrade_
 COPY CONDARC ./.condarc
 
 ENV PATH /usr/lib/rstudio-server/bin/:${PATH}
+
+ENV LD_LIBRARY_PATH=${CONDA_DIR}/lib:${LD_LIBRARY_PATH}
 
 # USER root
 # RUN chown -R jovyan ${CONDA_DIR}

--- a/r/Dockerfile
+++ b/r/Dockerfile
@@ -95,7 +95,8 @@ COPY CONDARC ./.condarc
 
 ENV PATH /usr/lib/rstudio-server/bin/:${PATH}
 
-ENV LD_LIBRARY_PATH=${CONDA_DIR}/lib:${LD_LIBRARY_PATH}
+ENV LD_LIBRARY_PATH=${CONDA_DIR}/lib
+ENV PROJ_LIB=${CONDA_DIR}/share/proj
 
 # USER root
 # RUN chown -R jovyan ${CONDA_DIR}

--- a/r/start
+++ b/r/start
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+export LD_LIBRARY_PATH=${NB_PYTHON_PREFIX}/lib:${LD_LIBRARY_PATH}
+exec "$@"

--- a/r/start
+++ b/r/start
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-export LD_LIBRARY_PATH=${NB_PYTHON_PREFIX}/lib:${LD_LIBRARY_PATH}
-exec "$@"


### PR DESCRIPTION
From: https://discourse.jupyter.org/t/glibcxx-3-4-26-not-found-from-rstudio/7778/7
May fix: https://github.com/oceanhackweek/ohw-tutorials/issues/94

The issue is that RStudio is looking into the system `/usr/lib/x86_64-linux-gnu/libstdc++.so.6` instead of conda's.

xref.: https://github.com/jupyterhub/repo2docker/issues/1153