### PR TITLE
Add entrypoint for Python image

### DIFF
--- a/py-base/Dockerfile
+++ b/py-base/Dockerfile
@@ -32,7 +32,10 @@ RUN --mount=type=cache,id=ohw_py,target=/opt/conda/pkgs,uid=${NB_UID},gid=${NB_U
     find -name '__pycache__' -type d -exec rm -rf '{}' '+'
 
 COPY CONDARC ./.condarc
+COPY --chown=${NB_USER} entrypoint.sh /opt/entrypoint.sh
 
 # USER root
 # RUN chown -R jovyan ${CONDA_DIR}
 USER ${NB_USER}
+
+ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/py-base/entrypoint.sh
+++ b/py-base/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/bash -l
+exec "$@"


### PR DESCRIPTION
Needs an entrypoint to allow the conda environment to fully activate when running a notebook or console. 

https://github.com/2i2c-org/infrastructure/issues/1576#issuecomment-1218529257