### PR TITLE
Add hadolint pre-commit hook and fix flagged Dockerfile issues

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,4 @@
+ignored:
+  # These images intentionally run as named users (jovyan, root) rather than
+  # numeric UIDs; switching would risk breaking downstream permissions/infra.
+  - DL3066

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,11 @@ repos:
     hooks:
       - id: actionlint-docker
 
+  - repo: https://github.com/hadolint/hadolint
+    rev: 2eece55955ced00200be9729e9728cb7dacca505  # frozen: v2.15.1
+    hooks:
+      - id: hadolint-docker
+
 update:
   cooldown_days: 7
   freeze: true

--- a/py-base/Dockerfile
+++ b/py-base/Dockerfile
@@ -23,8 +23,9 @@ RUN adduser --disabled-password --gecos "Default Jupyter user" ${NB_USER} \
 
 
 RUN apt-get update \
-    && apt-get install ca-certificates -y \
-    && update-ca-certificates
+    && apt-get install --no-install-recommends -y ca-certificates=20260601~22.04.1 \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 
 WORKDIR ${PIXI_DIR}

--- a/r/Dockerfile
+++ b/r/Dockerfile
@@ -29,25 +29,25 @@ RUN adduser --disabled-password --gecos "Default Jupyter user" ${NB_USER} \
 RUN --mount=type=cache,id=ohw_r_apt,target=/var/cache/apt \
     apt-get update -qq --yes > /dev/null && \
     apt-get install --yes --no-install-recommends -qq \
-    curl \
-    git \
-    less \
-    tar \
-    tzdata \
-    vim \
-    wget \
-    locales \
-    psmisc \
-    sudo \
+    curl=7.88.1-10+deb12u15 \
+    git=1:2.39.5-0+deb12u3 \
+    less=590-2.1~deb12u2 \
+    tar=1.34+dfsg-1.2+deb12u1 \
+    tzdata=2026b-0+deb12u1 \
+    vim=2:9.0.1378-2+deb12u2 \
+    wget=1.21.3-1+deb12u1 \
+    locales=2.36-9+deb12u14 \
+    psmisc=23.6-1 \
+    sudo=1.9.13p3-1+deb12u4 \
     # 11/14/24: should this lib version be udpated?
-    libapparmor1 \
-    libfmt-dev \
+    libapparmor1=3.0.8-3 \
+    libfmt-dev=9.1.0+ds1-2 \
     # 11/14/24: should this lib version be udpated?
-    libpq5 \
-    libssl-dev \
-    lsb-release \
-    ca-certificates \
-    libclang-dev > /dev/null \
+    libpq5=15.18-0+deb12u1 \
+    libssl-dev=3.0.20-1~deb12u2 \
+    lsb-release=12.0-1 \
+    ca-certificates=20250419~deb12u1 \
+    libclang-dev=1:14.0-55.7~deb12u1 > /dev/null \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
@@ -76,10 +76,10 @@ RUN --mount=type=cache,id=ohw_r,target=${CONDA_DIR}/pkgs,uid=${NB_UID},gid=${NB_
     conda config --add channels conda-forge && \
     conda update --all && \
     conda install --name ${CONDA_ENV} --file /tmp/conda-linux-64.lock && \
-    find -name '*.a' -delete && \
+    find . -name '*.a' -delete && \
     # rm -rf /opt/conda/conda-meta && \
     rm -rf ${CONDA_DIR}/include && \
-    find -name '__pycache__' -type d -exec rm -rf '{}' '+'
+    find . -name '__pycache__' -type d -exec rm -rf '{}' '+'
 
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 


### PR DESCRIPTION
Pins apt package versions in both Dockerfiles, adds
--no-install-recommends and apt list cleanup to py-base/Dockerfile
(r/Dockerfile already had these), and quotes an unanchored `find` in
r/Dockerfile. DL3066 (non-numeric USER) is ignored via .hadolint.yaml
since both images intentionally run as named users.

Assisted-by: Claude Code:claude-sonnet-5