### PR TITLE
Devcontainer for Codespaces

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,13 @@
+# Codespaces devcontainer
+
+This devcontainer is for updating and trying the `py-base` pixi environment, not for
+building the production Docker image (use `make py-build` / `docker compose` for that,
+which also work here since Docker-in-Docker is enabled).
+
+## Usage
+
+- `cd py-base`
+- `pixi add -f <feature-name> <packages...>` to add dependencies to a tutorial feature.
+- `pixi install` to refresh the lockfile after editing `pixi.toml` by hand.
+- `pixi run lab` to launch JupyterLab on port 8080 (forwarded automatically) and try the environment.
+- `make py-build` (from the repo root) to build and smoke-test the real Docker image.

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "2.17.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c",
+      "integrity": "sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "name": "OHW Python (pixi)",
+  "image": "mcr.microsoft.com/devcontainers/base:jammy",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  },
+  "onCreateCommand": "PIXI_VERSION=v0.76.2 bash -c 'curl -fsSL https://pixi.sh/install.sh | bash'",
+  "postCreateCommand": "cd py-base && $HOME/.pixi/bin/pixi install --frozen -e default",
+  "remoteEnv": {
+    "PATH": "${containerEnv:HOME}/.pixi/bin:${containerEnv:PATH}"
+  },
+  "forwardPorts": [8080],
+  "portsAttributes": {
+    "8080": {
+      "label": "JupyterLab",
+      "onAutoForward": "openBrowser"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-toolsai.jupyter",
+        "ms-python.python",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Set up a devcontainer for iterating on the Python image in Github Codespaces.

(Aka, I’d like to be able to not pixi install/docker build locally while tethering and iterating at the last minute on my way to Bamfield)